### PR TITLE
make url shortening work properly

### DIFF
--- a/src/features/urlShortener/URLInput.js
+++ b/src/features/urlShortener/URLInput.js
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { useDispatch } from "react-redux";
-import { shorten } from "./shortenerSlice";
+import { shortenUrl } from "./shortenerSlice";
 import "./URLInput.css";
 
 function URLInput() {
@@ -9,7 +9,7 @@ function URLInput() {
 
   const handleClick = () => {
     const inputValue = urlInput.current.value;
-    dispatch(shorten(inputValue));
+    dispatch(shortenUrl(inputValue));
   };
 
   return (

--- a/src/features/urlShortener/shortenerSlice.js
+++ b/src/features/urlShortener/shortenerSlice.js
@@ -7,26 +7,30 @@ export const shortenerSlice = createSlice({
     shortenedUrls: [],
   },
   reducers: {
-    shorten: (state, action) => {
-      const url = `https://api.shrtco.de/v2/shorten?url=${action.payload}`;
-      axios
-        .post(url)
-        .then((response) => {
-          const data = response.data;
-          const newUrlObject = {
-            originalUrl: action.payload,
-            shortenedUrl: data.result.full_short_link,
-          };
-          state.shortenedUrls.append(newUrlObject);
-        })
-        .catch(function (error) {
-          console.log(error);
-        });
-      console.log("hello");
+    saveShortenedUrl: (state, action) => {
+      state.shortenedUrls = [...state.shortenedUrls, action.payload];
     },
   },
 });
 
-export const { shorten } = shortenerSlice.actions;
+export function shortenUrl(originalUrl) {
+  return async (dispatch) => {
+    const url = `https://api.shrtco.de/v2/shorten?url=${originalUrl}`;
+    axios
+      .post(url)
+      .then((response) => {
+        const data = response.data;
+        dispatch(saveShortenedUrl({
+          originalUrl: originalUrl,
+          shortenedUrl: data.result.full_short_link,
+        }));
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
+};
+
+export const { shorten, saveShortenedUrl } = shortenerSlice.actions;
 
 export default shortenerSlice.reducer;


### PR DESCRIPTION
Hey Alex, I updated the shortening function to work properly. Apparently redux doesn't really support execution of asynchronous functions (such as network requests) inside reducers, so I created a separate function for URL shortening. This function will call a reducer once it has fetched the shortened URL. And the reducer itself will just save it to the state.